### PR TITLE
BUILD(docker): Add Nginx to handle client requests and static files

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,8 +8,8 @@ services:
       context: .
       dockerfile: prod.Dockerfile
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000
-    ports:
-      - 8000:8000
+    expose:
+      - 8000
     env_file:
       - .env.prod
     depends_on:
@@ -18,12 +18,17 @@ services:
   db:
     container_name: postgres_moat
     image: postgres:12.0-alpine
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
       - .env.prod.db
+
+  nginx:
+    build: ./nginx
+    ports:
+      - 1337:80
+    depends_on:
+      - web
 
 volumes:
   postgres_data:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.19.0-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,16 @@
+upstream hello_django {
+    server web:8000;
+}
+
+server {
+
+    listen 80;
+
+    location / {
+        proxy_pass http://hello_django;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+}


### PR DESCRIPTION
Add the service to docker-compose.prod.yml, Dockerfile and nginx.conf.
Then, update the web service, in docker-compose.prod.yml, replacing ports(8000:8000) with expose(8000).
Now, port 8000 is only exposed internally, to other Docker services. The port will no longer be published to the host machine.